### PR TITLE
- Added a new fun command for a certain shark

### DIFF
--- a/commands/admincommands.py
+++ b/commands/admincommands.py
@@ -782,7 +782,7 @@ class AdminCommands(commands.Cog):
 	@IsValidChannel(ChannelType.LOBBY)
 	@IsAdmin()
 	async def OnSwapPlayers(self, ctx, player1:discord.Member, player2:discord.Member):
-		"""Swaps the player who is in a queue with someone who is in a match that has started
+		"""Swaps two players between a queue and a match
 
 		   **discord.Member:** <player1>
 		   One of the players you want to swap. They must be either in the queue or in a match that has already started.

--- a/commands/botcommands.py
+++ b/commands/botcommands.py
@@ -468,6 +468,23 @@ class BotCommands(commands.Cog):
 
 		await SendMessage(ctx, title=title, fields=[mmrField, matchField, mapField, playerField], color=discord.Color.blue())
 
+	@commands.command(name='slap')
+	async def OnSlapUser(self, ctx, member:discord.Member):
+		"""Slaps the user, preferably with a trout
+
+		   **discord.Member:** <member>
+		   The person you wish you slap.
+		"""
+
+		# First send the slap
+		await ctx.channel.send('{0.mention} slaps {1.mention} around a bit with a large trout'.format(ctx.author, member))
+
+		# Then clean up the request to avoid polluting chat
+		try:
+			await ctx.message.delete()
+		except:
+			pass
+
 	@OnJPP.error
 	@OnWhenDoesBeauloPlay.error
 	@OnRegisterPlayer.error
@@ -481,5 +498,6 @@ class BotCommands(commands.Cog):
 	@OnShowStats.error
 	@OnGolfIt.error
 	@OnUpdateStatus.error
+	@OnSlapUser.error
 	async def errorHandling(self, ctx, error):
 		await HandleError(ctx, error)

--- a/services/matchservice.py
+++ b/services/matchservice.py
@@ -374,6 +374,30 @@ class MatchService(object):
 			self.matchesStarted[key].map = map
 
 			await SendMessage(ctx, description='The map for Game #{} has been changed to {}.'.format(key, map), color=discord.Color.blue())
+
+			# Delete the old message
+			try:
+				await self.matchesStarted[key].matchMessage.delete()
+			except:
+				pass
+
+			try:
+				await self.matchesStarted[key].adminMessage.delete()
+			except:
+				pass
+
+			self.matchesStarted[key].matchMessage = None
+			self.matchesStarted[key].adminMessage = None
+			self.recentlySwappedMatches.append(key)
+
+			# Send an updated message
+			message, adminMessage = await self.SendMatchMessages(ctx, self.matchesStarted[key])
+
+			self.matchesStarted[key].matchMessage = message
+			self.matchesStarted[key].adminMessage = adminMessage
+
+			await self.WaitForMatchResult(ctx, key)
+
 		elif (len(self.queuedPlayers) > 0):
 			self.forcedMap = map
 			await SendMessage(ctx, description='The next map will be {}.'.format(map), color=discord.Color.blue())
@@ -396,6 +420,29 @@ class MatchService(object):
 			self.matchesStarted[key].map = selectedMap 
 
 			await SendMessage(ctx, description='The map for Game #{} has been changed to {}.'.format(key, selectedMap), color=discord.Color.blue())
+
+			# Delete the old message
+			try:
+				await self.matchesStarted[key].matchMessage.delete()
+			except:
+				pass
+
+			try:
+				await self.matchesStarted[key].adminMessage.delete()
+			except:
+				pass
+
+			self.matchesStarted[key].matchMessage = None
+			self.matchesStarted[key].adminMessage = None
+			self.recentlySwappedMatches.append(key)
+
+			# Send an updated message
+			message, adminMessage = await self.SendMatchMessages(ctx, self.matchesStarted[key])
+
+			self.matchesStarted[key].matchMessage = message
+			self.matchesStarted[key].adminMessage = adminMessage
+
+			await self.WaitForMatchResult(ctx, key)
 		else:
 			await SendMessage(ctx, description='You can only reroll a map when there is a match running.', color=discord.Color.red())
 
@@ -416,25 +463,33 @@ class MatchService(object):
 	
 		if (len(match.team1) > 0):
 			isFirst = True
+			mmrSum = 0
 			for player in match.team1:
 				if (isFirst):
 					isFirst = False
 				else:
 					team1Field['value'] += '\n'
+				mmrSum += player.mmr
 
 				team1Field['value'] += '{0.mention}'.format(player.user)
+
+			team1Field['name'] = '[{}] {}'.format(mmrSum, team1Field['name'])
 		else:
 			team1Field['value'] = 'Empty'
 
 		if (len(match.team2) > 0):
 			isFirst = True
+			mmrSum = 0
 			for player in match.team2:
 				if (isFirst):
 					isFirst = False
 				else:
 					team2Field['value'] += '\n'
+				mmrSum += player.mmr
 
 				team2Field['value'] += '{0.mention}'.format(player.user)
+
+			team2Field['name'] = '[{}] {}'.format(mmrSum, team2Field['name'])
 		else:
 			team2Field['value'] = 'Empty'
 


### PR DESCRIPTION
- Fixed the help command for admins. It was broken because the message was too long. It now splits up the fields into multiple pages to avoid the issue.
- The match service will now properly regenerate match messages if you decide to change the map with the !rerollmap or !forcemap commands
- Added team MMRs to the match message to visualize how well the bot did to match the teams