### PR TITLE
Docker image no longer needs rebuild after Python dependencies change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+discord.py
+emojis
+mongoengine

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 
 rm -rf jppbot
-
-pip3 install mongoengine discord.py emojis
 git clone https://github.com/zylozs/jppbot.git
-
 cd jppbot
+pip3 install -r requirements.txt
 
 python3 jppbot.py --ip=$1 --port=$2 --token=$3


### PR DESCRIPTION
Python dependencies are now "data-driven" and exposed directly as a file in the repository (```requirements.txt```), 

Now the ```run.sh``` script will just be responsible for pulling the repository from GitHub and install the dependencies found there (in the ```requirements.txt file```), as opposed to previously where they were "frozen in place" in the Docker image when building it, as the ```run.sh``` was directly included in the image.